### PR TITLE
添加endpoint 的env模式，修复bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ biuld方法：
 
 注：
 ```
+    容器的endpoint获取有两种方式，1：对被监控的容器传入env，EndPoint=myendpoint 方式；2：通过获取被监控的容器的hosts文件的第一个ip地址
     --volume=/sys:/sys:ro 此volume中包含docker容器监控所需要的重要内容，如/sys/fs/cgroup下的相关内容
     --volume=/home/work/log/cadvisor/:/home/work/uploadCadviosrData/log \ 为日志内容路径
     --env Interval=60 表示提取数据的间隔时间

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ biuld方法：
 
 注：
 ```
-    容器的endpoint获取有两种方式，1：对被监控的容器传入env，EndPoint=myendpoint 方式；2：通过获取被监控的容器的hosts文件的第一个ip地址
+    容器的endpoint获取有两种方式:
+    1,对被监控的容器传入env，EndPoint=myendpoint 方式；
+    2,通过获取被监控的容器的hosts文件的第一个ip地址
     --volume=/sys:/sys:ro 此volume中包含docker容器监控所需要的重要内容，如/sys/fs/cgroup下的相关内容
     --volume=/home/work/log/cadvisor/:/home/work/uploadCadviosrData/log \ 为日志内容路径
     --env Interval=60 表示提取数据的间隔时间

--- a/getDatas.go
+++ b/getDatas.go
@@ -88,6 +88,11 @@ func getContainerId(cadvisorData string) string {
 }
 
 func getEndPoint(DockerData string) string {
+	//get endpoint from env first
+	endPoint := getBetween(DockerData, `"EndPoint=`, `",`)
+	if endPoint != "" {
+		return endPoint
+	}
 	filepath := getBetween(DockerData, `"HostsPath":"`, `",`)
 	buf := make(map[int]string, 6)
 	inputFile, inputError := os.Open(filepath)
@@ -108,6 +113,7 @@ func getEndPoint(DockerData string) string {
 		buf[lineCounter] = inputString
 	}
 	hostname := strings.Split(buf[1], "	")[0]
+	hostname = strings.Replace(hostname, "\n", " ", -1)
 	return hostname
 }
 


### PR DESCRIPTION
获取容器endpoint会优先查看env，如果env中有EndPoint项，就去env中的endpoint，否则用hosts文件的第一个ip作为容器endpoint
修复bug，修正endpoint中的\n字符
